### PR TITLE
Added Coingecko support to the pricer Oracle...

### DIFF
--- a/Spook.sln
+++ b/Spook.sln
@@ -38,6 +38,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StorageAnalyser", "StorageA
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TxSender", "TxSender\TxSender.csproj", "{FDC2C82A-9B51-40C2-A092-8356764A2888}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Phantasma.Ethereum", "..\PhantasmaChain\Phantasma.Ethereum\Phantasma.Ethereum.csproj", "{602FE6A6-9B6F-43DC-8C0B-1FB4B90339C7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -116,6 +118,10 @@ Global
 		{FDC2C82A-9B51-40C2-A092-8356764A2888}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FDC2C82A-9B51-40C2-A092-8356764A2888}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FDC2C82A-9B51-40C2-A092-8356764A2888}.Release|Any CPU.Build.0 = Release|Any CPU
+		{602FE6A6-9B6F-43DC-8C0B-1FB4B90339C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{602FE6A6-9B6F-43DC-8C0B-1FB4B90339C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{602FE6A6-9B6F-43DC-8C0B-1FB4B90339C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{602FE6A6-9B6F-43DC-8C0B-1FB4B90339C7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Spook/Command/CommandDispatcher.Oracle.cs
+++ b/Spook/Command/CommandDispatcher.Oracle.cs
@@ -7,6 +7,8 @@ using Phantasma.VM.Utils;
 using Phantasma.Core.Types;
 using Phantasma.Blockchain;
 using Phantasma.Storage.Context;
+using Phantasma.Spook.Oracles;
+using Phantasma.Domain;
 using System.Text;
 using System.IO;
 
@@ -14,6 +16,34 @@ namespace Phantasma.Spook.Command
 {
     partial class CommandDispatcher
     {
+
+        [ConsoleCommand("oracle get price", Category = "Oracle", Description = "Get current token price from an oracle")]
+        protected void OnOracleGetPriceCommand(string[] args)
+        {
+            var apiKey = _cli.CryptoCompareAPIKey;
+            var pricerCGEnabled = _cli.Settings.Oracle.PricerCoinGeckoEnabled;
+            var pricerSupportedTokens = _cli.Settings.Oracle.PricerSupportedTokens.ToArray();
+
+
+            Console.WriteLine($"Supported tokens:");
+            Console.WriteLine($"---------------------------");
+
+            foreach (var token in pricerSupportedTokens) {
+                Console.WriteLine($"{token.ticker}: {token.cryptocompareId}: {token.coingeckoId}");
+            }
+            Console.WriteLine($"---------------------------");
+
+            if(pricerCGEnabled) { 
+                var cgprice = CoinGeckoUtils.GetCoinRate(args[0], DomainSettings.FiatTokenSymbol, pricerSupportedTokens);
+                Console.WriteLine($"Oracle Coingecko Price for token {args[0]} is: {cgprice}");
+            }
+            var price = CryptoCompareUtils.GetCoinRate(args[0], DomainSettings.FiatTokenSymbol, apiKey, pricerSupportedTokens);
+            Console.WriteLine($"Oracle CryptoCompare Price for token {args[0]} is: {price}");
+
+            var gprice = Pricer.GetCoinRate(args[0], DomainSettings.FiatTokenSymbol, apiKey, pricerCGEnabled, pricerSupportedTokens);
+            Console.WriteLine($"Oracle Global Price for token {args[0]} is: {gprice}");
+        }
+
         [ConsoleCommand("oracle read", Category = "Oracle", Description="Read a transaction from an oracle")]
         protected void OnOracleReadCommand(string[] args)
         {

--- a/Spook/Modules/NexusModule.cs
+++ b/Spook/Modules/NexusModule.cs
@@ -6,6 +6,7 @@ using Phantasma.Blockchain;
 using Phantasma.Core.Log;
 using Phantasma.Numerics;
 using Phantasma.Spook.Command;
+using Phantasma.Domain;
 
 namespace Phantasma.Spook.Modules
 {
@@ -30,7 +31,7 @@ namespace Phantasma.Spook.Modules
             var oldGenesisBlock = oldNexus.GetGenesisBlock();
 
             var newNexus = new Nexus(oldNexus.Name);
-            newNexus.CreateGenesisBlock(owner, oldGenesisBlock.Timestamp, Phantasma.Spook.Spook.Protocol);
+            newNexus.CreateGenesisBlock(owner, oldGenesisBlock.Timestamp, DomainSettings.LatestKnownProtocol);
 
             var oldRootChain = oldNexus.RootChain;
             var newRootChain = newNexus.RootChain;

--- a/Spook/Oracles/CoinGecko.cs
+++ b/Spook/Oracles/CoinGecko.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using LunarLabs.Parser.JSON;
+using System.Net.Http;
+
+namespace Phantasma.Spook.Oracles
+{
+    public static class CoinGeckoUtils
+    {
+        public static decimal GetCoinRate(string baseSymbol, string quoteSymbol, PricerSupportedToken[] supportedTokens)
+        {
+
+            string json;
+            string baseticker = "";
+
+            foreach (var token in supportedTokens)
+            {
+                if(token.ticker == baseSymbol)
+                {
+                    baseticker = token.coingeckoId;
+                    break;
+                }
+            }
+
+            if (String.IsNullOrEmpty(baseticker))
+                return 0;
+
+            var url = $"https://api.coingecko.com/api/v3/simple/price?ids={baseticker}&vs_currencies={quoteSymbol}";
+
+            try
+            {
+
+                using (var httpClient = new HttpClient())
+                {
+                    json = httpClient.GetStringAsync(new Uri(url)).Result;
+                }
+
+                var root = JSONReader.ReadFromString(json);
+
+                // hack for goati price .10
+                if (baseticker == "GOATI")
+                {
+                    var price = 0.10m;
+                    return price;
+                }
+                else
+                {
+                    root = root[baseticker];
+                    var price = root.GetDecimal(quoteSymbol.ToLower());
+                    return price;
+                }
+
+            }
+            catch (Exception ex)
+            {
+                return 0;
+            }
+        }
+    }
+}

--- a/Spook/Oracles/CryptoCompare.cs
+++ b/Spook/Oracles/CryptoCompare.cs
@@ -1,12 +1,28 @@
-﻿using LunarLabs.Parser.JSON;
+﻿using System;
+using LunarLabs.Parser.JSON;
 
 namespace Phantasma.Spook.Oracles
 {
     public static class CryptoCompareUtils
     {
-        public static decimal GetCoinRate(string baseSymbol, string quoteSymbol, string APIKey)
+        public static decimal GetCoinRate(string baseSymbol, string quoteSymbol, string APIKey, PricerSupportedToken[] supportedTokens)
         {
-            var url = $"https://min-api.cryptocompare.com/data/price?fsym={baseSymbol}&tsyms={quoteSymbol}&api_key={APIKey}";
+
+            string baseticker = "";
+
+            foreach (var token in supportedTokens)
+            {
+                if (token.ticker == baseSymbol)
+                {
+                    baseticker = token.cryptocompareId;
+                    break;
+                }
+            }
+
+            if (String.IsNullOrEmpty(baseticker))
+                return 0;
+
+            var url = $"https://min-api.cryptocompare.com/data/price?fsym={baseticker}&tsyms={quoteSymbol}&api_key={APIKey}";
 
             string json;
 

--- a/Spook/Oracles/Pricer.cs
+++ b/Spook/Oracles/Pricer.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Phantasma.Domain;
+
+namespace Phantasma.Spook.Oracles
+{
+    public static class Pricer
+    {
+        public static decimal GetCoinRate(string baseSymbol, string quoteSymbol, string cryptoCompApiKey, bool cgEnabled, PricerSupportedToken[] supportedTokens)
+        {
+            try
+            {
+                Decimal cGeckoPrice = 0;
+                Decimal cCompare = 0;
+
+                cCompare = CryptoCompareUtils.GetCoinRate(baseSymbol, quoteSymbol, cryptoCompApiKey, supportedTokens);
+
+                if (cgEnabled)
+                {
+                    cGeckoPrice = CoinGeckoUtils.GetCoinRate(baseSymbol, quoteSymbol, supportedTokens);
+                }
+
+                if ((cGeckoPrice > 0) && (cCompare > 0))
+                {
+                    return ((cGeckoPrice + cCompare) / 2);
+                }
+                if((cGeckoPrice > 0) && (cCompare <= 0))
+                {
+                    return (cGeckoPrice);
+                }
+                if ((cCompare > 0) && (cGeckoPrice <= 0))
+                {
+                    return (cCompare);
+                }
+                return 0;
+
+            }
+            catch (Exception ex)
+            {
+                return 0;
+            }
+        }
+    }
+}

--- a/Spook/Oracles/SpookOracle.cs
+++ b/Spook/Oracles/SpookOracle.cs
@@ -202,6 +202,9 @@ namespace Phantasma.Spook.Oracles
         protected override decimal PullPrice(Timestamp time, string symbol)
         {
             var apiKey = _cli.CryptoCompareAPIKey;
+            var pricerCGEnabled = _cli.Settings.Oracle.PricerCoinGeckoEnabled;
+            var pricerSupportedTokens = _cli.Settings.Oracle.PricerSupportedTokens.ToArray();
+
             if (!string.IsNullOrEmpty(apiKey))
             {
                 if (symbol == DomainSettings.FuelTokenSymbol)
@@ -210,7 +213,8 @@ namespace Phantasma.Spook.Oracles
                     return result / 5;
                 }
 
-                var price = CryptoCompareUtils.GetCoinRate(symbol, DomainSettings.FiatTokenSymbol, apiKey);
+                //var price = CryptoCompareUtils.GetCoinRate(symbol, DomainSettings.FiatTokenSymbol, apiKey);
+                var price = Pricer.GetCoinRate(symbol, DomainSettings.FiatTokenSymbol, apiKey, pricerCGEnabled, pricerSupportedTokens);
                 return price;
             }
 

--- a/Spook/Settings.cs
+++ b/Spook/Settings.cs
@@ -329,12 +329,36 @@ namespace Phantasma.Spook
         }
     }
 
+    public class PricerSupportedToken
+    {
+        public PricerSupportedToken(string ticker, string coingeckoId, string cryptocompareId)
+        {
+            this.ticker = ticker;
+            this.coingeckoId = coingeckoId;
+            this.cryptocompareId = cryptocompareId;
+        }
+
+        public string ticker { get; set; }
+        public string coingeckoId { get; set; }
+        public string cryptocompareId { get; set; }
+
+        public static PricerSupportedToken FromNode(DataNode node)
+        {
+            var ticker = node.GetString("ticker");
+            var coingeckoId = node.GetString("coingeckoid");
+            var cryptocompareId = node.GetString("cryptocompareid");
+            return new PricerSupportedToken(ticker, coingeckoId, cryptocompareId);
+        }
+    }
+
     public class OracleSettings
     {
         public string NeoscanUrl { get; }
         public List<string> NeoRpcNodes { get; }
         public List<string> EthRpcNodes { get; }
         public List<FeeUrl> EthFeeURLs { get; }
+        public bool PricerCoinGeckoEnabled { get; } = true;
+        public List<PricerSupportedToken> PricerSupportedTokens { get; }
         public string CryptoCompareAPIKey { get; }
         public string Swaps { get; }
         public string SwapColdStorageNeo { get; }
@@ -346,7 +370,7 @@ namespace Phantasma.Spook
         public uint EthConfirmations { get; }
         public uint EthGasLimit { get; }
         public bool NeoQuickSync { get; } = true;
-
+        
         public OracleSettings(Arguments settings, DataNode section)
         {
             this.NeoscanUrl = settings.GetString("neoscan.api", section.GetString("neoscan.api"));
@@ -365,7 +389,10 @@ namespace Phantasma.Spook
                         .ToList();
 
             this.EthFeeURLs = section.GetNode("eth.fee.urls").Children.Select(x => FeeUrl.FromNode(x)).ToList();
-            
+
+            this.PricerCoinGeckoEnabled = settings.GetBool("pricer.coingecko.enabled", section.GetBool("pricer.coingecko.enabled"));
+            this.PricerSupportedTokens = section.GetNode("pricer.supportedtokens").Children.Select(x => PricerSupportedToken.FromNode(x)).ToList();
+
             this.EthConfirmations = settings.GetUInt("eth.block.confirmations", section.GetUInt32("eth.block.confirmations"));
             this.EthGasLimit = settings.GetUInt("eth.gas.limit", section.GetUInt32("eth.gas.limit"));
             this.CryptoCompareAPIKey = settings.GetString("crypto.compare.key", section.GetString("crypto.compare.key"));

--- a/Spook/Spook.Node.csproj
+++ b/Spook/Spook.Node.csproj
@@ -26,7 +26,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="LunarLabs.Parser" Version="1.3.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />

--- a/Spook/Spook.Node.csproj
+++ b/Spook/Spook.Node.csproj
@@ -32,6 +32,7 @@
 
     <PackageReference Include="Nethereum.Accounts" Version="3.8.0" />
     <PackageReference Include="Nethereum.Contracts" Version="3.8.0" />
+    <PackageReference Include="Nethereum.StandardNonFungibleTokenERC721" Version="3.8.0" />
     <PackageReference Include="Nethereum.StandardTokenEIP20" Version="3.8.0" />
     <PackageReference Include="Nethereum.Util" Version="3.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/Spook/Spook.cs
+++ b/Spook/Spook.cs
@@ -46,8 +46,6 @@ namespace Phantasma.Spook
 
     public class Spook : Runnable
     {
-        public static readonly int Protocol = 6;
-
         public readonly string LogPath;
         public readonly SpookSettings Settings;
 
@@ -324,7 +322,7 @@ namespace Phantasma.Spook
 
                         var genesisTimestamp = Settings.Node.GenesisTimestamp;
 
-                        if (!_nexus.CreateGenesisBlock(_nodeKeys, genesisTimestamp, Phantasma.Spook.Spook.Protocol))
+                        if (!_nexus.CreateGenesisBlock(_nodeKeys, genesisTimestamp, DomainSettings.LatestKnownProtocol))
                         {
                             throw new ChainException("Genesis block failure");
                         }

--- a/Spook/Spook.cs
+++ b/Spook/Spook.cs
@@ -352,16 +352,22 @@ namespace Phantasma.Spook
             else
             {
                 var genesisAddress = _nexus.GetGenesisAddress(_nexus.RootStorage);
-                if (Settings.Node.IsValidator && _nodeKeys.Address != genesisAddress && !Settings.Node.Readonly)
+                if (Settings.Node.IsValidator && !Settings.Node.Readonly)
                 {
-                    throw new Exception("Specified node key does not match genesis address " + genesisAddress.Text);
+                    if (!_nexus.IsKnownValidator(_nodeKeys.Address))
+                    {
+                        throw new Exception("Specified node key does not match a known validator address");
+                    }
+                    else
+                    if (_nodeKeys.Address != genesisAddress)
+                    {
+                        Logger.Warning("Specified node key does not match genesis address " + genesisAddress.Text);
+                    }
                 }
-                else
-                {
-                    var chainHeight = _nexus.RootChain.Height;
-                    var genesisHash = _nexus.GetGenesisHash(_nexus.RootStorage);
-                    Logger.Success($"Loaded {Nexus.Name} Nexus with genesis {genesisHash } with {chainHeight} blocks");
-                }
+
+                var chainHeight = _nexus.RootChain.Height;
+                var genesisHash = _nexus.GetGenesisHash(_nexus.RootStorage);
+                Logger.Success($"Loaded {Nexus.Name} Nexus with genesis {genesisHash } with {chainHeight} blocks");
             }
 
             return node;

--- a/Spook/config_mainnet.json
+++ b/Spook/config_mainnet.json
@@ -72,7 +72,74 @@
           "feeIncrease": 40
         }
       ],
-
+      "pricer.coingecko.enabled": true,
+      "pricer.supportedtokens": [
+        {
+          "ticker": "SOUL",
+          "coingeckoid": "phantasma",
+          "cryptocompareid": "SOUL"
+        },
+        {
+          "ticker": "KCAL",
+          "coingeckoid": "phantasma-energy",
+          "cryptocompareid": "KCAL"
+        },
+        {
+          "ticker": "NEO",
+          "coingeckoid": "neo",
+          "cryptocompareid": "NEO"
+        },
+        {
+          "ticker": "GAS",
+          "coingeckoid": "gas",
+          "cryptocompareid": "GAS"
+        },
+        {
+          "ticker": "USDT",
+          "coingeckoid": "tether",
+          "cryptocompareid": "USDT"
+        },
+        {
+          "ticker": "ETH",
+          "coingeckoid": "ethereum",
+          "cryptocompareid": "ETH"
+        },
+        {
+          "ticker": "DAI",
+          "coingeckoid": "dai",
+          "cryptocompareid": "DAI"
+        },
+        {
+          "ticker": "DYT",
+          "coingeckoid": "dynamite",
+          "cryptocompareid": "DYT"
+        },
+        {
+          "ticker": "DANK",
+          "coingeckoid": "mu-dank",
+          "cryptocompareid": "DANK"
+        },
+        {
+          "ticker": "GOATI",
+          "coingeckoid": "GOATI",
+          "cryptocompareid": "GOATI"
+        },
+        {
+          "ticker": "USDC",
+          "coingeckoid": "usd-coin",
+          "cryptocompareid": "USDC"
+        },
+        {
+          "ticker": "BNB",
+          "coingeckoid": "binancecoin",
+          "cryptocompareid": "BNB"
+        },
+        {
+          "ticker": "BUSD",
+          "coingeckoid": "binance-usd",
+          "cryptocompareid": "BNB"
+        }
+      ],
       "eth.block.confirmations": 12,
       "eth.gas.limit": 50000,
       "crypto.compare.key": "########################################################",

--- a/Spook/config_testnet.json
+++ b/Spook/config_testnet.json
@@ -64,7 +64,74 @@
           "feeIncrease": 40
         }
       ],
-
+      "pricer.coingecko.enabled": true,
+      "pricer.supportedtokens": [
+        {
+          "ticker": "SOUL",
+          "coingeckoid": "phantasma",
+          "cryptocompareid": "SOUL"
+        },
+        {
+          "ticker": "KCAL",
+          "coingeckoid": "phantasma-energy",
+          "cryptocompareid": "KCAL"
+        },
+        {
+          "ticker": "NEO",
+          "coingeckoid": "neo",
+          "cryptocompareid": "NEO"
+        },
+        {
+          "ticker": "GAS",
+          "coingeckoid": "gas",
+          "cryptocompareid": "GAS"
+        },
+        {
+          "ticker": "USDT",
+          "coingeckoid": "tether",
+          "cryptocompareid": "USDT"
+        },
+        {
+          "ticker": "ETH",
+          "coingeckoid": "ethereum",
+          "cryptocompareid": "ETH"
+        },
+        {
+          "ticker": "DAI",
+          "coingeckoid": "dai",
+          "cryptocompareid": "DAI"
+        },
+        {
+          "ticker": "DYT",
+          "coingeckoid": "dynamite",
+          "cryptocompareid": "DYT"
+        },
+        {
+          "ticker": "DANK",
+          "coingeckoid": "mu-dank",
+          "cryptocompareid": "DANK"
+        },
+        {
+          "ticker": "GOATI",
+          "coingeckoid": "GOATI",
+          "cryptocompareid": "GOATI"
+        },
+        {
+          "ticker": "USDC",
+          "coingeckoid": "usd-coin",
+          "cryptocompareid": "USDC"
+        },
+        {
+          "ticker": "BNB",
+          "coingeckoid": "binancecoin",
+          "cryptocompareid": "BNB"
+        },
+        {
+          "ticker": "BUSD",
+          "coingeckoid": "binance-usd",
+          "cryptocompareid": "BNB"
+        }
+      ],
       "eth.block.confirmations": 12,
       "eth.gas.limit": 100000,
       "crypto.compare.key": "",


### PR DESCRIPTION
Based in new properties at config.json file:

pricer.coingecko.enabled
pricer.supportedtokens

The pricer will query prices for the given token on cryptocompare and coingecko. If the token is active in both oracles it will return the average price.