### PR TITLE
Added Coingecko support to the pricer Oracle...

### DIFF
--- a/Spook/Command/CommandDispatcher.Oracle.cs
+++ b/Spook/Command/CommandDispatcher.Oracle.cs
@@ -34,13 +34,13 @@ namespace Phantasma.Spook.Command
             Console.WriteLine($"---------------------------");
 
             if(pricerCGEnabled) { 
-                var cgprice = CoinGeckoUtils.GetCoinRate(args[0], DomainSettings.FiatTokenSymbol, pricerSupportedTokens);
+                var cgprice = CoinGeckoUtils.GetCoinRate(args[0], DomainSettings.FiatTokenSymbol, pricerSupportedTokens, Spook.Logger);
                 Console.WriteLine($"Oracle Coingecko Price for token {args[0]} is: {cgprice}");
             }
-            var price = CryptoCompareUtils.GetCoinRate(args[0], DomainSettings.FiatTokenSymbol, apiKey, pricerSupportedTokens);
+            var price = CryptoCompareUtils.GetCoinRate(args[0], DomainSettings.FiatTokenSymbol, apiKey, pricerSupportedTokens, Spook.Logger);
             Console.WriteLine($"Oracle CryptoCompare Price for token {args[0]} is: {price}");
 
-            var gprice = Pricer.GetCoinRate(args[0], DomainSettings.FiatTokenSymbol, apiKey, pricerCGEnabled, pricerSupportedTokens);
+            var gprice = Pricer.GetCoinRate(args[0], DomainSettings.FiatTokenSymbol, apiKey, pricerCGEnabled, pricerSupportedTokens, Spook.Logger);
             Console.WriteLine($"Oracle Global Price for token {args[0]} is: {gprice}");
         }
 

--- a/Spook/Command/CommandDispatcher.Oracle.cs
+++ b/Spook/Command/CommandDispatcher.Oracle.cs
@@ -7,6 +7,8 @@ using Phantasma.VM.Utils;
 using Phantasma.Core.Types;
 using Phantasma.Blockchain;
 using Phantasma.Storage.Context;
+using Phantasma.Spook.Oracles;
+using Phantasma.Domain;
 using System.Text;
 using System.IO;
 
@@ -14,6 +16,34 @@ namespace Phantasma.Spook.Command
 {
     partial class CommandDispatcher
     {
+
+        [ConsoleCommand("oracle get price", Category = "Oracle", Description = "Get current token price from an oracle")]
+        protected void OnOracleGetPriceCommand(string[] args)
+        {
+            var apiKey = _cli.CryptoCompareAPIKey;
+            var pricerCGEnabled = _cli.Settings.Oracle.PricerCoinGeckoEnabled;
+            var pricerSupportedTokens = _cli.Settings.Oracle.PricerSupportedTokens.ToArray();
+
+
+            Console.WriteLine($"Supported tokens:");
+            Console.WriteLine($"---------------------------");
+
+            foreach (var token in pricerSupportedTokens) {
+                Console.WriteLine($"{token.ticker}: {token.cryptocompareId}: {token.coingeckoId}");
+            }
+            Console.WriteLine($"---------------------------");
+
+            if(pricerCGEnabled) { 
+                var cgprice = CoinGeckoUtils.GetCoinRate(args[0], DomainSettings.FiatTokenSymbol, pricerSupportedTokens);
+                Console.WriteLine($"Oracle Coingecko Price for token {args[0]} is: {cgprice}");
+            }
+            var price = CryptoCompareUtils.GetCoinRate(args[0], DomainSettings.FiatTokenSymbol, apiKey, pricerSupportedTokens);
+            Console.WriteLine($"Oracle CryptoCompare Price for token {args[0]} is: {price}");
+
+            var gprice = Pricer.GetCoinRate(args[0], DomainSettings.FiatTokenSymbol, apiKey, pricerCGEnabled, pricerSupportedTokens);
+            Console.WriteLine($"Oracle Global Price for token {args[0]} is: {gprice}");
+        }
+
         [ConsoleCommand("oracle read", Category = "Oracle", Description="Read a transaction from an oracle")]
         protected void OnOracleReadCommand(string[] args)
         {

--- a/Spook/Oracles/CoinGecko.cs
+++ b/Spook/Oracles/CoinGecko.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using LunarLabs.Parser.JSON;
+using System.Net.Http;
+
+namespace Phantasma.Spook.Oracles
+{
+    public static class CoinGeckoUtils
+    {
+        public static decimal GetCoinRate(string baseSymbol, string quoteSymbol, PricerSupportedToken[] supportedTokens)
+        {
+
+            string json;
+            string baseticker = "";
+
+            foreach (var token in supportedTokens)
+            {
+                if(token.ticker == baseSymbol)
+                {
+                    baseticker = token.coingeckoId;
+                    break;
+                }
+            }
+
+            if (String.IsNullOrEmpty(baseticker))
+                return 0;
+
+            var url = $"https://api.coingecko.com/api/v3/simple/price?ids={baseticker}&vs_currencies={quoteSymbol}";
+
+            try
+            {
+
+                using (var httpClient = new HttpClient())
+                {
+                    json = httpClient.GetStringAsync(new Uri(url)).Result;
+                }
+
+                var root = JSONReader.ReadFromString(json);
+
+                // hack for goati price .10
+                if (baseticker == "GOATI")
+                {
+                    var price = 0.10m;
+                    return price;
+                }
+                else
+                {
+                    root = root[baseticker];
+                    var price = root.GetDecimal(quoteSymbol.ToLower());
+                    return price;
+                }
+
+            }
+            catch (Exception ex)
+            {
+                return 0;
+            }
+        }
+    }
+}

--- a/Spook/Oracles/CryptoCompare.cs
+++ b/Spook/Oracles/CryptoCompare.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using LunarLabs.Parser.JSON;
 
+using Logger = Phantasma.Core.Log.Logger;
+
 namespace Phantasma.Spook.Oracles
 {
     public static class CryptoCompareUtils
     {
-        public static decimal GetCoinRate(string baseSymbol, string quoteSymbol, string APIKey, PricerSupportedToken[] supportedTokens)
+        
+        public static decimal GetCoinRate(string baseSymbol, string quoteSymbol, string APIKey, PricerSupportedToken[] supportedTokens, Logger logger)
         {
 
             string baseticker = "";
@@ -33,14 +36,18 @@ namespace Phantasma.Spook.Oracles
                     json = wc.DownloadString(url);
                 }
 
-                var root = JSONReader.ReadFromString(json);
+                if (String.IsNullOrEmpty(json))
+                    return 0;
 
+                var root = JSONReader.ReadFromString(json);
                 var price = root.GetDecimal(quoteSymbol);
 
                 return price;
             }
-            catch
+            catch (Exception ex)
             {
+                var errorMsg = ex.Message;
+                logger.Error($"Error while trying to query {baseticker} price from CryptoCompare API: {errorMsg}");
                 return 0;
             }
         }

--- a/Spook/Oracles/CryptoCompare.cs
+++ b/Spook/Oracles/CryptoCompare.cs
@@ -1,12 +1,28 @@
-﻿using LunarLabs.Parser.JSON;
+﻿using System;
+using LunarLabs.Parser.JSON;
 
 namespace Phantasma.Spook.Oracles
 {
     public static class CryptoCompareUtils
     {
-        public static decimal GetCoinRate(string baseSymbol, string quoteSymbol, string APIKey)
+        public static decimal GetCoinRate(string baseSymbol, string quoteSymbol, string APIKey, PricerSupportedToken[] supportedTokens)
         {
-            var url = $"https://min-api.cryptocompare.com/data/price?fsym={baseSymbol}&tsyms={quoteSymbol}&api_key={APIKey}";
+
+            string baseticker = "";
+
+            foreach (var token in supportedTokens)
+            {
+                if (token.ticker == baseSymbol)
+                {
+                    baseticker = token.cryptocompareId;
+                    break;
+                }
+            }
+
+            if (String.IsNullOrEmpty(baseticker))
+                return 0;
+
+            var url = $"https://min-api.cryptocompare.com/data/price?fsym={baseticker}&tsyms={quoteSymbol}&api_key={APIKey}";
 
             string json;
 

--- a/Spook/Oracles/Pricer.cs
+++ b/Spook/Oracles/Pricer.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Phantasma.Domain;
+
+namespace Phantasma.Spook.Oracles
+{
+    public static class Pricer
+    {
+        public static decimal GetCoinRate(string baseSymbol, string quoteSymbol, string cryptoCompApiKey, bool cgEnabled, PricerSupportedToken[] supportedTokens)
+        {
+            try
+            {
+                Decimal cGeckoPrice = 0;
+                Decimal cCompare = 0;
+
+                cCompare = CryptoCompareUtils.GetCoinRate(baseSymbol, quoteSymbol, cryptoCompApiKey, supportedTokens);
+
+                if (cgEnabled)
+                {
+                    cGeckoPrice = CoinGeckoUtils.GetCoinRate(baseSymbol, quoteSymbol, supportedTokens);
+                }
+
+                if ((cGeckoPrice > 0) && (cCompare > 0))
+                {
+                    return ((cGeckoPrice + cCompare) / 2);
+                }
+                if((cGeckoPrice > 0) && (cCompare <= 0))
+                {
+                    return (cGeckoPrice);
+                }
+                if ((cCompare > 0) && (cGeckoPrice <= 0))
+                {
+                    return (cCompare);
+                }
+                return 0;
+
+            }
+            catch (Exception ex)
+            {
+                return 0;
+            }
+        }
+    }
+}

--- a/Spook/Oracles/Pricer.cs
+++ b/Spook/Oracles/Pricer.cs
@@ -1,41 +1,45 @@
 ﻿using System;
 using Phantasma.Domain;
 
+using Logger = Phantasma.Core.Log.Logger;
+
 namespace Phantasma.Spook.Oracles
 {
     public static class Pricer
     {
-        public static decimal GetCoinRate(string baseSymbol, string quoteSymbol, string cryptoCompApiKey, bool cgEnabled, PricerSupportedToken[] supportedTokens)
+        public static decimal GetCoinRate(string baseSymbol, string quoteSymbol, string cryptoCompApiKey, bool cgEnabled, PricerSupportedToken[] supportedTokens, Logger logger)
         {
             try
             {
                 Decimal cGeckoPrice = 0;
-                Decimal cCompare = 0;
+                Decimal cComparePrice = 0;
 
-                cCompare = CryptoCompareUtils.GetCoinRate(baseSymbol, quoteSymbol, cryptoCompApiKey, supportedTokens);
+                cComparePrice = CryptoCompareUtils.GetCoinRate(baseSymbol, quoteSymbol, cryptoCompApiKey, supportedTokens, logger);
 
                 if (cgEnabled)
                 {
-                    cGeckoPrice = CoinGeckoUtils.GetCoinRate(baseSymbol, quoteSymbol, supportedTokens);
+                    cGeckoPrice = CoinGeckoUtils.GetCoinRate(baseSymbol, quoteSymbol, supportedTokens, logger);
                 }
 
-                if ((cGeckoPrice > 0) && (cCompare > 0))
+                if ((cGeckoPrice > 0) && (cComparePrice > 0))
                 {
-                    return ((cGeckoPrice + cCompare) / 2);
+                    return ((cGeckoPrice + cComparePrice) / 2);
                 }
-                if((cGeckoPrice > 0) && (cCompare <= 0))
+                if((cGeckoPrice > 0) && (cComparePrice <= 0))
                 {
                     return (cGeckoPrice);
                 }
-                if ((cCompare > 0) && (cGeckoPrice <= 0))
+                if ((cComparePrice > 0) && (cGeckoPrice <= 0))
                 {
-                    return (cCompare);
+                    return (cComparePrice);
                 }
                 return 0;
 
             }
             catch (Exception ex)
             {
+                var errorMsg = ex.ToString();
+                logger.Error($"Pricer error: {errorMsg}");
                 return 0;
             }
         }

--- a/Spook/Oracles/SpookOracle.cs
+++ b/Spook/Oracles/SpookOracle.cs
@@ -202,6 +202,9 @@ namespace Phantasma.Spook.Oracles
         protected override decimal PullPrice(Timestamp time, string symbol)
         {
             var apiKey = _cli.CryptoCompareAPIKey;
+            var pricerCGEnabled = _cli.Settings.Oracle.PricerCoinGeckoEnabled;
+            var pricerSupportedTokens = _cli.Settings.Oracle.PricerSupportedTokens.ToArray();
+
             if (!string.IsNullOrEmpty(apiKey))
             {
                 if (symbol == DomainSettings.FuelTokenSymbol)
@@ -210,7 +213,8 @@ namespace Phantasma.Spook.Oracles
                     return result / 5;
                 }
 
-                var price = CryptoCompareUtils.GetCoinRate(symbol, DomainSettings.FiatTokenSymbol, apiKey);
+                //var price = CryptoCompareUtils.GetCoinRate(symbol, DomainSettings.FiatTokenSymbol, apiKey);
+                var price = Pricer.GetCoinRate(symbol, DomainSettings.FiatTokenSymbol, apiKey, pricerCGEnabled, pricerSupportedTokens);
                 return price;
             }
 

--- a/Spook/Oracles/SpookOracle.cs
+++ b/Spook/Oracles/SpookOracle.cs
@@ -214,7 +214,7 @@ namespace Phantasma.Spook.Oracles
                 }
 
                 //var price = CryptoCompareUtils.GetCoinRate(symbol, DomainSettings.FiatTokenSymbol, apiKey);
-                var price = Pricer.GetCoinRate(symbol, DomainSettings.FiatTokenSymbol, apiKey, pricerCGEnabled, pricerSupportedTokens);
+                var price = Pricer.GetCoinRate(symbol, DomainSettings.FiatTokenSymbol, apiKey, pricerCGEnabled, pricerSupportedTokens, logger);
                 return price;
             }
 

--- a/Spook/Settings.cs
+++ b/Spook/Settings.cs
@@ -329,12 +329,36 @@ namespace Phantasma.Spook
         }
     }
 
+    public class PricerSupportedToken
+    {
+        public PricerSupportedToken(string ticker, string coingeckoId, string cryptocompareId)
+        {
+            this.ticker = ticker;
+            this.coingeckoId = coingeckoId;
+            this.cryptocompareId = cryptocompareId;
+        }
+
+        public string ticker { get; set; }
+        public string coingeckoId { get; set; }
+        public string cryptocompareId { get; set; }
+
+        public static PricerSupportedToken FromNode(DataNode node)
+        {
+            var ticker = node.GetString("ticker");
+            var coingeckoId = node.GetString("coingeckoid");
+            var cryptocompareId = node.GetString("cryptocompareid");
+            return new PricerSupportedToken(ticker, coingeckoId, cryptocompareId);
+        }
+    }
+
     public class OracleSettings
     {
         public string NeoscanUrl { get; }
         public List<string> NeoRpcNodes { get; }
         public List<string> EthRpcNodes { get; }
         public List<FeeUrl> EthFeeURLs { get; }
+        public bool PricerCoinGeckoEnabled { get; } = true;
+        public List<PricerSupportedToken> PricerSupportedTokens { get; }
         public string CryptoCompareAPIKey { get; }
         public string Swaps { get; }
         public string SwapColdStorageNeo { get; }
@@ -346,7 +370,7 @@ namespace Phantasma.Spook
         public uint EthConfirmations { get; }
         public uint EthGasLimit { get; }
         public bool NeoQuickSync { get; } = true;
-
+        
         public OracleSettings(Arguments settings, DataNode section)
         {
             this.NeoscanUrl = settings.GetString("neoscan.api", section.GetString("neoscan.api"));
@@ -365,7 +389,10 @@ namespace Phantasma.Spook
                         .ToList();
 
             this.EthFeeURLs = section.GetNode("eth.fee.urls").Children.Select(x => FeeUrl.FromNode(x)).ToList();
-            
+
+            this.PricerCoinGeckoEnabled = settings.GetBool("pricer.coingecko.enabled", section.GetBool("pricer.coingecko.enabled"));
+            this.PricerSupportedTokens = section.GetNode("pricer.supportedtokens").Children.Select(x => PricerSupportedToken.FromNode(x)).ToList();
+
             this.EthConfirmations = settings.GetUInt("eth.block.confirmations", section.GetUInt32("eth.block.confirmations"));
             this.EthGasLimit = settings.GetUInt("eth.gas.limit", section.GetUInt32("eth.gas.limit"));
             this.CryptoCompareAPIKey = settings.GetString("crypto.compare.key", section.GetString("crypto.compare.key"));

--- a/Spook/config_mainnet.json
+++ b/Spook/config_mainnet.json
@@ -72,7 +72,74 @@
           "feeIncrease": 40
         }
       ],
-
+      "pricer.coingecko.enabled": true,
+      "pricer.supportedtokens": [
+        {
+          "ticker": "SOUL",
+          "coingeckoid": "phantasma",
+          "cryptocompareid": "SOUL"
+        },
+        {
+          "ticker": "KCAL",
+          "coingeckoid": "phantasma-energy",
+          "cryptocompareid": "KCAL"
+        },
+        {
+          "ticker": "NEO",
+          "coingeckoid": "neo",
+          "cryptocompareid": "NEO"
+        },
+        {
+          "ticker": "GAS",
+          "coingeckoid": "gas",
+          "cryptocompareid": "GAS"
+        },
+        {
+          "ticker": "USDT",
+          "coingeckoid": "tether",
+          "cryptocompareid": "USDT"
+        },
+        {
+          "ticker": "ETH",
+          "coingeckoid": "ethereum",
+          "cryptocompareid": "ETH"
+        },
+        {
+          "ticker": "DAI",
+          "coingeckoid": "dai",
+          "cryptocompareid": "DAI"
+        },
+        {
+          "ticker": "DYT",
+          "coingeckoid": "dynamite",
+          "cryptocompareid": "DYT"
+        },
+        {
+          "ticker": "DANK",
+          "coingeckoid": "mu-dank",
+          "cryptocompareid": "DANK"
+        },
+        {
+          "ticker": "GOATI",
+          "coingeckoid": "GOATI",
+          "cryptocompareid": "GOATI"
+        },
+        {
+          "ticker": "USDC",
+          "coingeckoid": "usd-coin",
+          "cryptocompareid": "USDC"
+        },
+        {
+          "ticker": "BNB",
+          "coingeckoid": "binancecoin",
+          "cryptocompareid": "BNB"
+        },
+        {
+          "ticker": "BUSD",
+          "coingeckoid": "binance-usd",
+          "cryptocompareid": "BNB"
+        }
+      ],
       "eth.block.confirmations": 12,
       "eth.gas.limit": 50000,
       "crypto.compare.key": "########################################################",

--- a/Spook/config_testnet.json
+++ b/Spook/config_testnet.json
@@ -64,7 +64,74 @@
           "feeIncrease": 40
         }
       ],
-
+      "pricer.coingecko.enabled": true,
+      "pricer.supportedtokens": [
+        {
+          "ticker": "SOUL",
+          "coingeckoid": "phantasma",
+          "cryptocompareid": "SOUL"
+        },
+        {
+          "ticker": "KCAL",
+          "coingeckoid": "phantasma-energy",
+          "cryptocompareid": "KCAL"
+        },
+        {
+          "ticker": "NEO",
+          "coingeckoid": "neo",
+          "cryptocompareid": "NEO"
+        },
+        {
+          "ticker": "GAS",
+          "coingeckoid": "gas",
+          "cryptocompareid": "GAS"
+        },
+        {
+          "ticker": "USDT",
+          "coingeckoid": "tether",
+          "cryptocompareid": "USDT"
+        },
+        {
+          "ticker": "ETH",
+          "coingeckoid": "ethereum",
+          "cryptocompareid": "ETH"
+        },
+        {
+          "ticker": "DAI",
+          "coingeckoid": "dai",
+          "cryptocompareid": "DAI"
+        },
+        {
+          "ticker": "DYT",
+          "coingeckoid": "dynamite",
+          "cryptocompareid": "DYT"
+        },
+        {
+          "ticker": "DANK",
+          "coingeckoid": "mu-dank",
+          "cryptocompareid": "DANK"
+        },
+        {
+          "ticker": "GOATI",
+          "coingeckoid": "GOATI",
+          "cryptocompareid": "GOATI"
+        },
+        {
+          "ticker": "USDC",
+          "coingeckoid": "usd-coin",
+          "cryptocompareid": "USDC"
+        },
+        {
+          "ticker": "BNB",
+          "coingeckoid": "binancecoin",
+          "cryptocompareid": "BNB"
+        },
+        {
+          "ticker": "BUSD",
+          "coingeckoid": "binance-usd",
+          "cryptocompareid": "BNB"
+        }
+      ],
       "eth.block.confirmations": 12,
       "eth.gas.limit": 100000,
       "crypto.compare.key": "",


### PR DESCRIPTION
Based in new properties at config.json file:

pricer.coingecko.enabled
pricer.supportedtokens

The pricer will query prices for the given token on cryptocompare and coingecko. If the token is active in both oracles it will return the average price.